### PR TITLE
Don't specify stable version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           stable: false
+          go-version: '^1'
 
       - name: Vet
         run: go vet
@@ -63,6 +64,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           stable: false
+          go-version: '^1'
 
       - name: Build
         run: go build -v ./...
@@ -78,6 +80,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           stable: false
+          go-version: '^1'
 
       - name: Test
         run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          stable: false
 
       - name: Vet
         run: go vet
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          stable: false
 
       - name: Build
         run: go build -v ./...
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          stable: false
 
       - name: Test
         run: go test -v ./...


### PR DESCRIPTION
This should default to the latest version, since go has a compatibility pledge, the build should work with all future versions unless something is really broken

Resolves #122 